### PR TITLE
add SearchRepositoryWithCount

### DIFF
--- a/src/main/kotlin/no/liflig/documentstore/dao/Dao.kt
+++ b/src/main/kotlin/no/liflig/documentstore/dao/Dao.kt
@@ -360,6 +360,7 @@ inline fun <T> mapExceptions(block: () -> T): T {
       is InterruptedIOException,
       is ConnectionException,
       is CloseException -> throw UnavailableDaoException(e)
+      is NoCountReceivedFromSearchQueryException -> throw e
 
       else -> throw UnknownDaoException(e)
     }

--- a/src/main/kotlin/no/liflig/documentstore/dao/SearchRepositoryWithCount.kt
+++ b/src/main/kotlin/no/liflig/documentstore/dao/SearchRepositoryWithCount.kt
@@ -19,8 +19,7 @@ EntityT : EntityRoot<EntityIdT> {
 }
 
 /**
- * Extends the [AbstractSearchRepository] from liflig-document-store with methods for getting the
- * count of rows in the database table.
+ * Extends [AbstractSearchRepository] with functionality for getting the count of objects in the database table.
  */
 abstract class AbstractSearchRepositoryWithCount<EntityIdT, EntityT, SearchQueryT>(
   jdbi: Jdbi,
@@ -38,6 +37,12 @@ EntityT : EntityRoot<EntityIdT> {
   protected open val rowMapperWithCount =
     createRowMapperWithCount(createRowParserWithCount(::fromJson))
 
+  /**
+   * Gets database objects matching the given parameters, and the total count of objects in the database.
+   *
+   * This can be used for pagination: for example, if passing e.g. `limit = 10` to display 10 items in a page at a time,
+   * the count can be used to display the number of pages.
+   */
   protected open fun getByPredicateWithCount(
     sqlWhere: String = "TRUE",
     limit: Int? = null,

--- a/src/main/kotlin/no/liflig/documentstore/dao/SearchRepositoryWithCount.kt
+++ b/src/main/kotlin/no/liflig/documentstore/dao/SearchRepositoryWithCount.kt
@@ -148,7 +148,7 @@ fun <EntityT : EntityRoot<*>> createRowParserWithCount(
   return { row ->
     /** @see EntityRowWithCount */
     val entity =
-      if (row.data != null && row.version != null)
+      if (row.id != null && row.data != null && row.version != null)
         VersionedEntity(fromJson(row.data), Version(row.version))
       else null
 

--- a/src/main/kotlin/no/liflig/documentstore/dao/SearchRepositoryWithCount.kt
+++ b/src/main/kotlin/no/liflig/documentstore/dao/SearchRepositoryWithCount.kt
@@ -1,0 +1,144 @@
+package no.liflig.documentstore.dao
+
+import no.liflig.documentstore.entity.EntityId
+import no.liflig.documentstore.entity.EntityRoot
+import no.liflig.documentstore.entity.Version
+import no.liflig.documentstore.entity.VersionedEntity
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.kotlin.KotlinMapper
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.Query
+import java.util.UUID
+
+interface SearchRepositoryWithCount<EntityIdT, EntityT, SearchQueryT> :
+  SearchRepository<EntityIdT, EntityT, SearchQueryT> where
+EntityIdT : EntityId,
+EntityT : EntityRoot<EntityIdT> {
+  fun searchWithCount(query: SearchQueryT): Pair<List<VersionedEntity<EntityT>>, Long>
+}
+
+/**
+ * Extends the [AbstractSearchRepository] from liflig-document-store with methods for getting the
+ * count of rows in the database table.
+ */
+abstract class AbstractSearchRepositoryWithCount<EntityIdT, EntityT, SearchQueryT>(
+  jdbi: Jdbi,
+  sqlTableName: String,
+  serializationAdapter: SerializationAdapter<EntityT>,
+) :
+  SearchRepositoryWithCount<EntityIdT, EntityT, SearchQueryT>,
+  AbstractSearchRepository<EntityIdT, EntityT, SearchQueryT>(
+    jdbi, sqlTableName, serializationAdapter
+  ) where
+EntityIdT : EntityId,
+EntityT : EntityRoot<EntityIdT> {
+  private fun fromJson(value: String): EntityT = serializationAdapter.fromJson(value)
+
+  protected open val rowMapperWithCount =
+    createRowMapperWithCount(createRowParserWithCount(::fromJson))
+
+  protected open fun getByPredicateWithCount(
+    sqlWhere: String = "TRUE",
+    limit: Int? = null,
+    offset: Int? = null,
+    orderBy: String? = null,
+    orderDesc: Boolean = false,
+    bind: Query.() -> Query = { this }
+  ): Pair<List<VersionedEntity<EntityT>>, Long> = mapExceptions {
+    val transaction = transactionHandle.get()
+
+    if (transaction != null) {
+      innerGetByPredicateWithCount(sqlWhere, transaction, limit, offset, orderBy, orderDesc, bind)
+    } else {
+      jdbi.open().use { handle ->
+        innerGetByPredicateWithCount(sqlWhere, handle, limit, offset, orderBy, orderDesc, bind)
+      }
+    }
+  }
+
+  private fun innerGetByPredicateWithCount(
+    sqlWhere: String,
+    handle: Handle,
+    limit: Int? = null,
+    offset: Int? = null,
+    orderBy: String? = null,
+    desc: Boolean = false,
+    bind: Query.() -> Query = { this }
+  ): Pair<List<VersionedEntity<EntityT>>, Long> {
+    val limitString = limit?.let { "LIMIT $it" } ?: ""
+    val offsetString = offset?.let { "OFFSET $it" } ?: ""
+    val orderDirection = if (desc) "DESC" else "ASC"
+    val orderByString = orderBy ?: "created_at"
+
+    val rows =
+      handle
+        .select(
+          // SQL query based on https://stackoverflow.com/a/28888696
+          // Uses a RIGHT JOIN with the count in order to still get the count when no rows are
+          // returned.
+          """
+              WITH base_query AS (
+                  SELECT id, data, version, created_at, modified_at
+                  FROM "$sqlTableName"
+                  WHERE ($sqlWhere)
+              )
+              SELECT id, data, version, created_at, modified_at, count
+              FROM (
+                  TABLE base_query
+                  ORDER BY $orderByString $orderDirection
+                  $limitString
+                  $offsetString
+              ) sub_query
+              RIGHT JOIN (
+                  SELECT count(*) FROM base_query
+              ) c(count) ON true
+          """.trimIndent()
+        )
+        .bind()
+        .map(rowMapperWithCount)
+        .list()
+
+    val entities = rows.mapNotNull { row -> row.first }
+    val count = rows.firstOrNull()?.second ?: throw NoCountReceivedFromSearchQueryException
+    return Pair(entities, count)
+  }
+}
+
+/**
+ * In the case where no rows are returned, our SQL count query will return a single row where all
+ * fields except `count` are `NULL`. Thus, `id`, `data` and `version` are nullable here.
+ */
+data class EntityRowWithCount(
+  val id: UUID?,
+  val data: String?,
+  val version: Long?,
+  val count: Long,
+)
+
+fun <EntityT : EntityRoot<*>> createRowMapperWithCount(
+  fromRow: (row: EntityRowWithCount) -> Pair<VersionedEntity<EntityT>?, Long>
+): RowMapper<Pair<VersionedEntity<EntityT>?, Long>> {
+  val kotlinMapper = KotlinMapper(EntityRowWithCount::class.java)
+
+  return RowMapper { rs, ctx ->
+    val simpleRow = kotlinMapper.map(rs, ctx) as EntityRowWithCount
+    fromRow(simpleRow)
+  }
+}
+
+fun <EntityT : EntityRoot<*>> createRowParserWithCount(
+  fromJson: (String) -> EntityT
+): (row: EntityRowWithCount) -> Pair<VersionedEntity<EntityT>?, Long> {
+  return { row ->
+    /** @see EntityRowWithCount */
+    val entity =
+      if (row.data != null && row.version != null)
+        VersionedEntity(fromJson(row.data), Version(row.version))
+      else null
+
+    Pair(entity, row.count)
+  }
+}
+
+data object NoCountReceivedFromSearchQueryException : RuntimeException()

--- a/src/test/kotlin/no/liflig/documentstore/ExampleSearchRepository.kt
+++ b/src/test/kotlin/no/liflig/documentstore/ExampleSearchRepository.kt
@@ -4,36 +4,76 @@ package no.liflig.documentstore
 
 import kotlinx.serialization.UseSerializers
 import no.liflig.documentstore.dao.AbstractSearchRepository
+import no.liflig.documentstore.dao.AbstractSearchRepositoryWithCount
 import no.liflig.documentstore.dao.SerializationAdapter
 import no.liflig.documentstore.entity.VersionedEntity
 import org.jdbi.v3.core.Jdbi
 
-class ExampleQueryObject
+data class ExampleQueryObject(
+  val limit: Int? = null,
+  val offset: Int? = null,
+  val orderBy: OrderBy? = null,
+  val orderDesc: Boolean = false,
+)
+
+enum class OrderBy {
+  TEXT,
+  CREATED_AT,
+}
 
 class ExampleSearchRepository(
   jdbi: Jdbi,
   sqlTableName: String,
   serializationAdapter: SerializationAdapter<ExampleEntity>
-) : AbstractSearchRepository<ExampleId, ExampleEntity, ExampleQueryObject>(jdbi, sqlTableName, serializationAdapter) {
-  enum class OrderBy {
-    TEXT,
-    CREATED_AT,
-  }
-
+) :
+  AbstractSearchRepository<ExampleId, ExampleEntity, ExampleQueryObject>(
+    jdbi, sqlTableName, serializationAdapter
+  ) {
   override fun listByIds(ids: List<ExampleId>): List<VersionedEntity<ExampleEntity>> {
     TODO("Not yet implemented")
   }
 
   override fun search(query: ExampleQueryObject): List<VersionedEntity<ExampleEntity>> =
-    TODO("Not yet implemented")
-
-  fun search(limit: Int? = null, offset: Int? = null, orderBy: OrderBy? = null, orderDesc: Boolean = false) =
     getByPredicate(
-      limit = limit, offset = offset, orderDesc = orderDesc,
-      orderBy = when (orderBy) {
+      limit = query.limit,
+      offset = query.offset,
+      orderDesc = query.orderDesc,
+      orderBy =
+      when (query.orderBy) {
         OrderBy.TEXT -> "data->>'text'"
         OrderBy.CREATED_AT -> "createdAt"
         null -> null
       }
     )
+}
+
+class ExampleSearchRepositoryWithCount(
+  jdbi: Jdbi,
+  sqlTableName: String,
+  serializationAdapter: SerializationAdapter<ExampleEntity>
+) :
+  AbstractSearchRepositoryWithCount<ExampleId, ExampleEntity, ExampleQueryObject>(
+    jdbi,
+    sqlTableName,
+    serializationAdapter,
+  ) {
+  override fun search(query: ExampleQueryObject): List<VersionedEntity<ExampleEntity>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun searchWithCount(
+    query: ExampleQueryObject
+  ): Pair<List<VersionedEntity<ExampleEntity>>, Long> {
+    return getByPredicateWithCount(
+      limit = query.limit,
+      offset = query.offset,
+      orderDesc = query.orderDesc,
+      orderBy =
+      when (query.orderBy) {
+        OrderBy.TEXT -> "data->>'text'"
+        OrderBy.CREATED_AT -> "createdAt"
+        null -> null
+      }
+    )
+  }
 }

--- a/src/test/kotlin/no/liflig/documentstore/ExampleSearchRepository.kt
+++ b/src/test/kotlin/no/liflig/documentstore/ExampleSearchRepository.kt
@@ -3,9 +3,7 @@
 package no.liflig.documentstore
 
 import kotlinx.serialization.UseSerializers
-import no.liflig.documentstore.dao.AbstractSearchRepository
-import no.liflig.documentstore.dao.AbstractSearchRepositoryWithCount
-import no.liflig.documentstore.dao.SerializationAdapter
+import no.liflig.documentstore.dao.*
 import no.liflig.documentstore.entity.VersionedEntity
 import org.jdbi.v3.core.Jdbi
 
@@ -63,7 +61,7 @@ class ExampleSearchRepositoryWithCount(
 
   override fun searchWithCount(
     query: ExampleQueryObject
-  ): Pair<List<VersionedEntity<ExampleEntity>>, Long> {
+  ): EntitiesWithCount<ExampleEntity> {
     return getByPredicateWithCount(
       limit = query.limit,
       offset = query.offset,

--- a/src/test/kotlin/no/liflig/documentstore/TransactionalTest.kt
+++ b/src/test/kotlin/no/liflig/documentstore/TransactionalTest.kt
@@ -306,11 +306,14 @@ class TransactionalTest {
       daoWithCount.create(ExampleEntity.create("B"))
       daoWithCount.create(ExampleEntity.create("C"))
 
-      val query = ExampleQueryObject(limit = 2, offset = 0)
-      val result = searchRepositoryWithCount.searchWithCount(query)
+      val queryWithLimitLessThanCount = ExampleQueryObject(limit = 2, offset = 0)
+      val result1 = searchRepositoryWithCount.searchWithCount(queryWithLimitLessThanCount)
+      assertEquals(result1.entities.size, queryWithLimitLessThanCount.limit)
+      assertEquals(result1.count, 3)
 
-      assertEquals(result.entities.size, query.limit)
-      assertEquals(result.count, 3)
+      val queryWithOffsetHigherThanCount = ExampleQueryObject(limit = 2, offset = 1000)
+      val result2 = searchRepositoryWithCount.searchWithCount(queryWithOffsetHigherThanCount)
+      assertEquals(result2.count, 3)
     }
   }
 

--- a/src/test/kotlin/no/liflig/documentstore/TransactionalTest.kt
+++ b/src/test/kotlin/no/liflig/documentstore/TransactionalTest.kt
@@ -307,10 +307,10 @@ class TransactionalTest {
       daoWithCount.create(ExampleEntity.create("C"))
 
       val query = ExampleQueryObject(limit = 2, offset = 0)
-      val (entities, count) = searchRepositoryWithCount.searchWithCount(query)
+      val result = searchRepositoryWithCount.searchWithCount(query)
 
-      assertEquals(entities.size, query.limit)
-      assertEquals(count, 3)
+      assertEquals(result.entities.size, query.limit)
+      assertEquals(result.count, 3)
     }
   }
 

--- a/src/test/kotlin/no/liflig/documentstore/TransactionalTest.kt
+++ b/src/test/kotlin/no/liflig/documentstore/TransactionalTest.kt
@@ -34,7 +34,9 @@ class TransactionalTest {
   val serializationAdapter = ExampleSerializationAdapter()
   val dao = CrudDaoJdbi(jdbi, "example", serializationAdapter)
   val searchRepository = ExampleSearchRepository(jdbi, "example", serializationAdapter)
-  val countDao = CrudDaoJdbi(jdbi, "example_with_count", serializationAdapter)
+
+  // Separate DAOs to avoid other tests interfering with the count returned by SearchRepositoryWithCount
+  val daoWithCount = CrudDaoJdbi(jdbi, "example_with_count", serializationAdapter)
   val searchRepositoryWithCount =
     ExampleSearchRepositoryWithCount(jdbi, "example_with_count", serializationAdapter)
 
@@ -300,9 +302,9 @@ class TransactionalTest {
   @Test
   fun testSearchRepositoryWithCount() {
     runBlocking {
-      countDao.create(ExampleEntity.create("A"))
-      countDao.create(ExampleEntity.create("B"))
-      countDao.create(ExampleEntity.create("C"))
+      daoWithCount.create(ExampleEntity.create("A"))
+      daoWithCount.create(ExampleEntity.create("B"))
+      daoWithCount.create(ExampleEntity.create("C"))
 
       val query = ExampleQueryObject(limit = 2, offset = 0)
       val (entities, count) = searchRepositoryWithCount.searchWithCount(query)

--- a/src/test/kotlin/no/liflig/documentstore/TransactionalTest.kt
+++ b/src/test/kotlin/no/liflig/documentstore/TransactionalTest.kt
@@ -34,13 +34,15 @@ class TransactionalTest {
   val serializationAdapter = ExampleSerializationAdapter()
   val dao = CrudDaoJdbi(jdbi, "example", serializationAdapter)
   val searchRepository = ExampleSearchRepository(jdbi, "example", serializationAdapter)
+  val countDao = CrudDaoJdbi(jdbi, "example_with_count", serializationAdapter)
+  val searchRepositoryWithCount =
+    ExampleSearchRepositoryWithCount(jdbi, "example_with_count", serializationAdapter)
 
   private fun getTransactionFunctions(): Stream<Arguments> {
     val co: Transactional = ::coTransactional
     val normal: Transactional = { a, b -> transactional(a) { runBlocking { b() } } }
     return Stream.of(
-      Arguments.of(Named.of("Non-suspending", normal)),
-      Arguments.of(Named.of("Suspending", co))
+      Arguments.of(Named.of("Non-suspending", normal)), Arguments.of(Named.of("Suspending", co))
     )
   }
 
@@ -49,11 +51,9 @@ class TransactionalTest {
     runBlocking {
       val agg = ExampleEntity.create("hello world")
 
-      dao
-        .create(agg)
+      dao.create(agg)
 
-      val read = dao
-        .get(agg.id)
+      val read = dao.get(agg.id)
 
       assertNotNull(read)
       assertEquals(Version.initial(), read.version)
@@ -66,13 +66,9 @@ class TransactionalTest {
     runBlocking {
       val agg = ExampleEntity.create("hello world")
 
-      val storeResult = dao
-        .create(agg)
+      val storeResult = dao.create(agg)
 
-      assertFailsWith<ConflictDaoException> {
-        dao
-          .update(agg, storeResult.version.next())
-      }
+      assertFailsWith<ConflictDaoException> { dao.update(agg, storeResult.version.next()) }
     }
   }
 
@@ -81,9 +77,7 @@ class TransactionalTest {
     runBlocking {
       val agg = ExampleEntity.create("hello world")
 
-      assertFailsWith<ConflictDaoException> {
-        dao.delete(agg.id, Version.initial())
-      }
+      assertFailsWith<ConflictDaoException> { dao.delete(agg.id, Version.initial()) }
 
       val res2 = dao.create(agg)
       assertEquals(Version.initial(), res2.version)
@@ -99,15 +93,12 @@ class TransactionalTest {
   @Test
   fun updateEntity() {
     runBlocking {
-      val (initialAgg, initialVersion) = dao
-        .create(ExampleEntity.create("hello world"))
+      val (initialAgg, initialVersion) = dao.create(ExampleEntity.create("hello world"))
 
       val updatedAgg = initialAgg.updateText("new value")
-      dao
-        .update(updatedAgg, initialVersion)
+      dao.update(updatedAgg, initialVersion)
 
-      val res = dao
-        .get(updatedAgg.id)
+      val res = dao.get(updatedAgg.id)
 
       assertNotNull(res)
       val (agg, version) = res
@@ -121,10 +112,8 @@ class TransactionalTest {
   @MethodSource("getTransactionFunctions")
   fun completeTransactionSucceeds(transactionBlock: Transactional) {
     runBlocking {
-      val (initialAgg1, initialVersion1) = dao
-        .create(ExampleEntity.create("One"))
-      val (initialAgg2, initialVersion2) = dao
-        .create(ExampleEntity.create("One"))
+      val (initialAgg1, initialVersion1) = dao.create(ExampleEntity.create("One"))
+      val (initialAgg2, initialVersion2) = dao.create(ExampleEntity.create("One"))
 
       transactionBlock(jdbi) {
         dao.update(initialAgg1.updateText("Two"), initialVersion1)
@@ -142,18 +131,15 @@ class TransactionalTest {
   @MethodSource("getTransactionFunctions")
   fun failedTransactionRollsBack(transactionBlock: Transactional) {
     runBlocking {
-      val (initialAgg1, initialVersion1) = dao
-        .create(ExampleEntity.create("One"))
-      val (initialAgg2, initialVersion2) = dao
-        .create(ExampleEntity.create("One"))
+      val (initialAgg1, initialVersion1) = dao.create(ExampleEntity.create("One"))
+      val (initialAgg2, initialVersion2) = dao.create(ExampleEntity.create("One"))
 
       try {
         transactionBlock(jdbi) {
           dao.update(initialAgg1.updateText("Two"), initialVersion1)
           dao.update(initialAgg2.updateText("Two"), initialVersion2.next())
         }
-      } catch (_: ConflictDaoException) {
-      }
+      } catch (_: ConflictDaoException) {}
 
       assertEquals("One", dao.get(initialAgg1.id)!!.item.text)
       assertEquals("One", dao.get(initialAgg2.id)!!.item.text)
@@ -164,10 +150,8 @@ class TransactionalTest {
   @MethodSource("getTransactionFunctions")
   fun failedTransactionWithExplicitHandleStartedOutsideRollsBack(transactionBlock: Transactional) {
     runBlocking {
-      val (initialAgg1, initialVersion1) = dao
-        .create(ExampleEntity.create("One"))
-      val (initialAgg2, initialVersion2) = dao
-        .create(ExampleEntity.create("One"))
+      val (initialAgg1, initialVersion1) = dao.create(ExampleEntity.create("One"))
+      val (initialAgg2, initialVersion2) = dao.create(ExampleEntity.create("One"))
 
       var exceptionThrown = false
       try {
@@ -191,18 +175,15 @@ class TransactionalTest {
   @MethodSource("getTransactionFunctions")
   fun failedTransactionFactoryRollsBack(transactionBlock: Transactional) {
     runBlocking {
-      val (initialAgg1, initialVersion1) = dao
-        .create(ExampleEntity.create("One"))
-      val (initialAgg2, initialVersion2) = dao
-        .create(ExampleEntity.create("One"))
+      val (initialAgg1, initialVersion1) = dao.create(ExampleEntity.create("One"))
+      val (initialAgg2, initialVersion2) = dao.create(ExampleEntity.create("One"))
 
       try {
         transactionBlock(jdbi) {
           dao.update(initialAgg1.updateText("Two"), initialVersion1)
           dao.update(initialAgg2.updateText("Two"), initialVersion2.next())
         }
-      } catch (_: ConflictDaoException) {
-      }
+      } catch (_: ConflictDaoException) {}
 
       assertEquals("One", dao.get(initialAgg1.id)!!.item.text)
       assertEquals("One", dao.get(initialAgg2.id)!!.item.text)
@@ -215,10 +196,8 @@ class TransactionalTest {
     runBlocking {
       val initialValue = "Initial"
       val updatedVaue = "Updated value"
-      val (initialAgg1, initialVersion1) = dao
-        .create(ExampleEntity.create(initialValue))
-      val (initialAgg2, initialVersion2) = dao
-        .create(ExampleEntity.create(initialValue))
+      val (initialAgg1, initialVersion1) = dao.create(ExampleEntity.create(initialValue))
+      val (initialAgg2, initialVersion2) = dao.create(ExampleEntity.create(initialValue))
 
       try {
         transactionBlock(jdbi) {
@@ -228,8 +207,7 @@ class TransactionalTest {
           }
           throw ConflictDaoException()
         }
-      } catch (_: ConflictDaoException) {
-      }
+      } catch (_: ConflictDaoException) {}
 
       assertEquals(initialValue, dao.get(initialAgg1.id)!!.item.text)
       assertEquals(initialValue, dao.get(initialAgg2.id)!!.item.text)
@@ -240,13 +218,13 @@ class TransactionalTest {
   @MethodSource("getTransactionFunctions")
   fun getReturnsUpdatedDataWithinTransaction(transactionBlock: Transactional) {
     runBlocking {
-      val (initialAgg1, initialVersion1) = dao
-        .create(ExampleEntity.create("One"))
+      val (initialAgg1, initialVersion1) = dao.create(ExampleEntity.create("One"))
 
-      val result = transactionBlock(jdbi) {
-        dao.update(initialAgg1.updateText("Two"), initialVersion1)
-        dao.get(initialAgg1.id)?.item?.text
-      }
+      val result =
+        transactionBlock(jdbi) {
+          dao.update(initialAgg1.updateText("Two"), initialVersion1)
+          dao.get(initialAgg1.id)?.item?.text
+        }
 
       assertEquals("Two", result)
     }
@@ -255,15 +233,17 @@ class TransactionalTest {
   @Test
   fun orderByOrdersByCorrectData() {
     runBlocking {
-      val (initialAgg1, _) = dao
-        .create(ExampleEntity.create("A"))
-      val (initialAgg2, _) = dao
-        .create(ExampleEntity.create("B"))
+      val (initialAgg1, _) = dao.create(ExampleEntity.create("A"))
+      val (initialAgg2, _) = dao.create(ExampleEntity.create("B"))
 
-      val result1 = searchRepository.search(orderBy = ExampleSearchRepository.OrderBy.TEXT, orderDesc = false)
-        .map { it.item }
-      val result2 = searchRepository.search(orderBy = ExampleSearchRepository.OrderBy.TEXT, orderDesc = true)
-        .map { it.item }
+      val result1 =
+        searchRepository
+          .search(ExampleQueryObject(orderBy = OrderBy.TEXT, orderDesc = false))
+          .map { it.item }
+      val result2 =
+        searchRepository
+          .search(ExampleQueryObject(orderBy = OrderBy.TEXT, orderDesc = true))
+          .map { it.item }
 
       result1.indexOf(initialAgg1) shouldBeLessThan result1.indexOf(initialAgg2)
       result2.indexOf(initialAgg1) shouldBeGreaterThan result2.indexOf(initialAgg2)
@@ -273,14 +253,12 @@ class TransactionalTest {
   @Test
   fun test() {
     runBlocking {
-      val (initialAgg1, _) = dao
-        .create(ExampleEntity.create("A", now = Instant.now()))
+      val (initialAgg1, _) = dao.create(ExampleEntity.create("A", now = Instant.now()))
 
-      val (initialAgg2, _) = dao
-        .create(ExampleEntity.create("B", now = Instant.now().minusSeconds(10000)))
+      val (initialAgg2, _) =
+        dao.create(ExampleEntity.create("B", now = Instant.now().minusSeconds(10000)))
 
-      val result1 = searchRepository.search(orderDesc = false)
-        .map { it.item }
+      val result1 = searchRepository.search(ExampleQueryObject(orderDesc = false)).map { it.item }
 
       val indexOf1 = result1.indexOf(initialAgg1)
       val indexOf2 = result1.indexOf(initialAgg2)
@@ -293,12 +271,28 @@ class TransactionalTest {
   }
 
   @Test
+  fun testSearchRepositoryWithCount() {
+    runBlocking {
+      countDao.create(ExampleEntity.create("A"))
+      countDao.create(ExampleEntity.create("B"))
+      countDao.create(ExampleEntity.create("C"))
+
+      val query = ExampleQueryObject(limit = 2, offset = 0)
+      val (entities, count) = searchRepositoryWithCount.searchWithCount(query)
+
+      assertEquals(entities.size, query.limit)
+      assertEquals(count, 3)
+    }
+  }
+
+  @Test
   fun verifySnapshot() {
-    val agg = ExampleEntity.create(
-      id = ExampleId(UUID.fromString("928f6ef3-6873-454a-a68d-ef3f5d7963b5")),
-      text = "hello world",
-      now = Instant.parse("2020-10-11T23:25:00Z")
-    )
+    val agg =
+      ExampleEntity.create(
+        id = ExampleId(UUID.fromString("928f6ef3-6873-454a-a68d-ef3f5d7963b5")),
+        text = "hello world",
+        now = Instant.parse("2020-10-11T23:25:00Z")
+      )
 
     verifyJsonSnapshot("Example.json", serializationAdapter.toJson(agg))
   }

--- a/src/test/resources/db/migrations/V001__initial.sql
+++ b/src/test/resources/db/migrations/V001__initial.sql
@@ -6,7 +6,7 @@ CREATE TABLE example (
   data jsonb NOT NULL
 );
 
--- Separate table to make SearchRepositoryWithCount tests independent
+-- Separate table to avoid other tests interfering with the count returned by SearchRepositoryWithCount
 CREATE TABLE example_with_count
 (
   id          uuid        NOT NULL PRIMARY KEY,

--- a/src/test/resources/db/migrations/V001__initial.sql
+++ b/src/test/resources/db/migrations/V001__initial.sql
@@ -6,7 +6,7 @@ CREATE TABLE example (
   data jsonb NOT NULL
 );
 
--- Separate table to ensure no
+-- Separate table to make SearchRepositoryWithCount tests independent
 CREATE TABLE example_with_count
 (
   id          uuid        NOT NULL PRIMARY KEY,

--- a/src/test/resources/db/migrations/V001__initial.sql
+++ b/src/test/resources/db/migrations/V001__initial.sql
@@ -5,3 +5,13 @@ CREATE TABLE example (
   version bigint NOT NULL,
   data jsonb NOT NULL
 );
+
+-- Separate table to ensure no
+CREATE TABLE example_with_count
+(
+  id          uuid        NOT NULL PRIMARY KEY,
+  created_at  timestamptz NOT NULL,
+  modified_at timestamptz NOT NULL,
+  version     bigint      NOT NULL,
+  data        jsonb       NOT NULL
+);


### PR DESCRIPTION
The `AbstractSearchRepository` in liflig-document-store currently has some support for pagination, through the `limit` and `offset` arguments. But when using pagination, one also often wants the total count of database objects from the query, in order to display the number of pages. Because of this, [we extended `AbstractSearchRepository` in the IDTAG project](https://github.com/capralifecycle/idtag-backend/blob/3a80307e5161d83cec3aa72ffd73592bb668811d/src/main/kotlin/no/liflig/idtag/common/repository/SearchRepositoryWithCount.kt), to enable getting this count in the same query. This PR proposes adding this change upstream to liflig-document-store, as we think this functionality would be useful for others doing pagination.

### Changes

- add `SearchRepositoryWithCount` interface with a `searchWithCount` method
- implement `AbstractSearchRepositoryWithCount`, which provides a `getByPredicateWithCount` method for fetching objects from the database and getting the total count in the same query
- add `testSearchRepositoryWithCount` to test the new repository

This should be a non-breaking change, since it does not change existing interfaces or implementations.