### PR TITLE
fix wildcard import

### DIFF
--- a/src/test/kotlin/no/liflig/documentstore/ExampleSearchRepository.kt
+++ b/src/test/kotlin/no/liflig/documentstore/ExampleSearchRepository.kt
@@ -3,7 +3,10 @@
 package no.liflig.documentstore
 
 import kotlinx.serialization.UseSerializers
-import no.liflig.documentstore.dao.*
+import no.liflig.documentstore.dao.AbstractSearchRepository
+import no.liflig.documentstore.dao.AbstractSearchRepositoryWithCount
+import no.liflig.documentstore.dao.EntitiesWithCount
+import no.liflig.documentstore.dao.SerializationAdapter
 import no.liflig.documentstore.entity.VersionedEntity
 import org.jdbi.v3.core.Jdbi
 


### PR DESCRIPTION
My previous PR (#30) failed to merge due to a wildcard import in `ExampleSearchRepository`, which `ktlint` disallows.