### PR TITLE
add generic search repository implementation

### DIFF
--- a/src/test/kotlin/no/liflig/documentstore/ExampleSearchRepository.kt
+++ b/src/test/kotlin/no/liflig/documentstore/ExampleSearchRepository.kt
@@ -6,9 +6,11 @@ import kotlinx.serialization.UseSerializers
 import no.liflig.documentstore.dao.AbstractSearchRepository
 import no.liflig.documentstore.dao.AbstractSearchRepositoryWithCount
 import no.liflig.documentstore.dao.EntitiesWithCount
+import no.liflig.documentstore.dao.SearchRepositoryQuery
 import no.liflig.documentstore.dao.SerializationAdapter
 import no.liflig.documentstore.entity.VersionedEntity
 import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.statement.Query
 
 data class ExampleQueryObject(
   val limit: Int? = null,
@@ -77,4 +79,14 @@ class ExampleSearchRepositoryWithCount(
       }
     )
   }
+}
+
+data class ExampleTextSearchQuery(
+  val text: String,
+  override val limit: Int? = null,
+  override val offset: Int? = null
+) : SearchRepositoryQuery() {
+  override val sqlWhere: String = "(data->>'text' ILIKE '%' || :text || '%')"
+
+  override val bindSqlParameters: Query.() -> Query = { bind("text", text) }
 }


### PR DESCRIPTION
After adding `SearchRepositoryWithCount` in the IDTAG project (which is now merged here as well after #30), we discovered a useful pattern: by placing search parameters on an extendable `SearchRepositoryQuery`, we could implement a generic `SearchRepositoryWithCount` for all queries that inherited from that base query type. This way, we only write the actual search queries with corresponding search strings, without needing to write any glue code. For an example of how this looks, see [CollectionSearchQuery in the IDTAG backend](https://github.com/capralifecycle/idtag-backend/blob/078709fb94affe12c45ab386b7e398d6a713996d/src/main/kotlin/no/liflig/idtag/tms/collection/repository/CollectionSearchQuery.kt).

Using this pattern, we no longer need to write a `SearchRepository` ourselves at all - we just [instantiate the generic implementation on startup](https://github.com/capralifecycle/idtag-backend/blob/078709fb94affe12c45ab386b7e398d6a713996d/src/main/kotlin/no/liflig/idtag/App.kt#L136), and it infers the entity type. In our opinion, this leads to more expressive code with less boilerplate, and is therefore something that we think other users of liflig-document-store may find useful.

This should be a non-breaking change, since it does not change existing interfaces or implementations.